### PR TITLE
fix hapi plugin import

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,15 +73,15 @@ plugin format. See: http://hapijs.com/tutorials/plugins#loading-a-plugin
 module.exports = {
   plugins: [
     {
-      register: require('vision'),
+      plugin: require('vision'),
       options: { }
     },
     {
-      register: require('inert'),
+      plugin: require('inert'),
       options: { }
     },
     {
-      register: require('hapi-auth-hawk'),
+      plugin: require('hapi-auth-hawk'),
       options: { }
     }
     // ...

--- a/lib/server.ts
+++ b/lib/server.ts
@@ -11,8 +11,7 @@ export const Server = {
 
     app.log.debug('spool-hapi: registering', app.config.get('web.plugins').length, 'plugins')
 
-    // await server.register(app.config.get('web.plugins'))
-    await server.register(require('inert'))
+    await server.register(app.config.get('web.plugins'))
 
     if (typeof app.config.get('web.onPluginsLoaded') === 'function') {
       app.config.get('web.onPluginsLoaded').call(app)


### PR DESCRIPTION
- install hapi plugins from web.plugins
- update README.md

#### Description
- Hapi plugins are not imported from web.plugins
- Hapi v17 passes an object with a `plugin`  property where the plugin is required. Previously it used the `register` object property.

#### Issues
- resolves #5
